### PR TITLE
Add zarr to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 napari-plugin-engine>=0.1.4
 dask[array]
 s3fs
+zarr


### PR DESCRIPTION
Zarr is only included as a testing or bundle dependency with napari. That means most users will not automatically have it installed. Since napari-s3zarr requires zarr, it should be listed here as a requirement.